### PR TITLE
Generating coverage.xml and disabled ruff warning

### DIFF
--- a/template/__.gitignore.fragment
+++ b/template/__.gitignore.fragment
@@ -2,5 +2,6 @@
 .DS_Store
 .vscode
 __pycache__
+coverage.xml
 minisign_key.pri
 post_generation_instructions.html

--- a/template/__pyproject.fragment.toml
+++ b/template/__pyproject.fragment.toml
@@ -24,7 +24,7 @@ Repository = "{{ github_url }}"
 path = "src/{{ python_package_name }}/__init__.py"
 
 [tool.pytest.ini_options]
-addopts = "--verbose -vv --capture=no --cov={{ python_package_name }} --cov-fail-under=95.0"
+addopts = "--verbose -vv --capture=no --cov={{ python_package_name }} --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
 
 [tool.ruff]
 line-length = 110
@@ -45,6 +45,7 @@ ignore = [
     "N802", # Function name `xxx` should be lowercase
     "N999", # Invalid module name
     "S101", # Use of assert detected
+    "TC006", # Add quotes to type expression in `typing.cast()`
     "UP032", # Use f-string instead of `format` call
 ]
 

--- a/tests/__snapshots__/All_EndToEndTest.ambr
+++ b/tests/__snapshots__/All_EndToEndTest.ambr
@@ -646,6 +646,7 @@
       .coverage
       .DS_Store
       .vscode
+      coverage.xml
       minisign_key.pri
       post_generation_instructions.html
     ''',
@@ -1431,7 +1432,7 @@
       path = "src/this_is_the_project_name/__init__.py"
       
       [tool.pytest.ini_options]
-      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-fail-under=95.0"
+      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
       
       [tool.ruff]
       line-length = 110
@@ -1452,6 +1453,7 @@
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
           "S101", # Use of assert detected
+          "TC006", # Add quotes to type expression in `typing.cast()`
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -2168,6 +2170,7 @@
       .coverage
       .DS_Store
       .vscode
+      coverage.xml
       minisign_key.pri
       post_generation_instructions.html
     ''',
@@ -2967,7 +2970,7 @@
       path = "src/this_is_the_project_name/__init__.py"
       
       [tool.pytest.ini_options]
-      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-fail-under=95.0"
+      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
       
       [tool.ruff]
       line-length = 110
@@ -2988,6 +2991,7 @@
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
           "S101", # Use of assert detected
+          "TC006", # Add quotes to type expression in `typing.cast()`
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -3704,6 +3708,7 @@
       .coverage
       .DS_Store
       .vscode
+      coverage.xml
       minisign_key.pri
       post_generation_instructions.html
     ''',
@@ -4501,7 +4506,7 @@
       path = "src/this_is_the_project_name/__init__.py"
       
       [tool.pytest.ini_options]
-      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-fail-under=95.0"
+      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
       
       [tool.ruff]
       line-length = 110
@@ -4522,6 +4527,7 @@
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
           "S101", # Use of assert detected
+          "TC006", # Add quotes to type expression in `typing.cast()`
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -5238,6 +5244,7 @@
       .coverage
       .DS_Store
       .vscode
+      coverage.xml
       minisign_key.pri
       post_generation_instructions.html
     ''',
@@ -6024,7 +6031,7 @@
       path = "src/this_is_the_project_name/__init__.py"
       
       [tool.pytest.ini_options]
-      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-fail-under=95.0"
+      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
       
       [tool.ruff]
       line-length = 110
@@ -6045,6 +6052,7 @@
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
           "S101", # Use of assert detected
+          "TC006", # Add quotes to type expression in `typing.cast()`
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -6761,6 +6769,7 @@
       .coverage
       .DS_Store
       .vscode
+      coverage.xml
       minisign_key.pri
       post_generation_instructions.html
     ''',
@@ -7554,7 +7563,7 @@
       path = "src/this_is_the_project_name/__init__.py"
       
       [tool.pytest.ini_options]
-      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-fail-under=95.0"
+      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
       
       [tool.ruff]
       line-length = 110
@@ -7575,6 +7584,7 @@
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
           "S101", # Use of assert detected
+          "TC006", # Add quotes to type expression in `typing.cast()`
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -8290,6 +8300,7 @@
       .coverage
       .DS_Store
       .vscode
+      coverage.xml
       minisign_key.pri
       post_generation_instructions.html
     ''',
@@ -9028,7 +9039,7 @@
       path = "src/this_is_the_project_name/__init__.py"
       
       [tool.pytest.ini_options]
-      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-fail-under=95.0"
+      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
       
       [tool.ruff]
       line-length = 110
@@ -9049,6 +9060,7 @@
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
           "S101", # Use of assert detected
+          "TC006", # Add quotes to type expression in `typing.cast()`
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -9765,6 +9777,7 @@
       .coverage
       .DS_Store
       .vscode
+      coverage.xml
       minisign_key.pri
       post_generation_instructions.html
     ''',
@@ -10509,7 +10522,7 @@
       path = "src/this_is_the_project_name/__init__.py"
       
       [tool.pytest.ini_options]
-      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-fail-under=95.0"
+      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
       
       [tool.ruff]
       line-length = 110
@@ -10530,6 +10543,7 @@
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
           "S101", # Use of assert detected
+          "TC006", # Add quotes to type expression in `typing.cast()`
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -11246,6 +11260,7 @@
       .coverage
       .DS_Store
       .vscode
+      coverage.xml
       minisign_key.pri
       post_generation_instructions.html
     ''',
@@ -12008,7 +12023,7 @@
       path = "src/this_is_the_project_name/__init__.py"
       
       [tool.pytest.ini_options]
-      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-fail-under=95.0"
+      addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
       
       [tool.ruff]
       line-length = 110
@@ -12029,6 +12044,7 @@
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
           "S101", # Use of assert detected
+          "TC006", # Add quotes to type expression in `typing.cast()`
           "UP032", # Use f-string instead of `format` call
       ]
       


### PR DESCRIPTION
## :pencil: Description
- Code coverage information will be written to the terminal and `coverage.xml` to work more effectively with tools such as [coverage gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters)
- Disabled ruff warning `TC006`

## :gear: Work Item
N/A

## :movie_camera: Demo
N/A