### PR TITLE
Disabled additional ruff warnings, updated readme text

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Copier (https://copier.readthedocs.io/) template to create [uv](https://docs.ast
 - GitHub [Issue Templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)
 - GitHub [Pull Request Template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)
 - Standard documentation (`CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, `GOVERNANCE.md`, `MAINTAINERS.md`, `README.md`, `SECURITY.md`)
-- [Optional] Generation of code coverage badge on `README.md`
+- [Optional] Generation of code coverage badge displayed on `README.md`
 - [Optional] Artifact signing via [py-minisign](https://github.com/x13a/py-minisign)
 
 ## How to use copier-UvScaffolding

--- a/template/__pyproject.fragment.toml
+++ b/template/__pyproject.fragment.toml
@@ -39,13 +39,21 @@ ignore = [
     "ANN003", # Missing type annotation for `**kwargs`
     "BLE001", # Do not catch blind exception: `Exception`
     "COM812", # Trailing comma missing
+    "D105", # Missing docstring in magic method
+    "D107", # Missing docstring in `__init__` method
     "D202", # No blank lines allowed after function docstring
     "E501", # Line too long
+    "FIX002", # Line contains TODO, consider resolving the issue
     "I001", # Import block is un-sorted or un-formatted
     "N802", # Function name `xxx` should be lowercase
     "N999", # Invalid module name
+    "RSE102", # Unnecessary parentheses on raise exception
     "S101", # Use of assert detected
     "TC006", # Add quotes to type expression in `typing.cast()`
+    "TD002", # Missing author in TODO
+    "TD003", # Missing issue link for this TODO
+    "TRY002", # Create your own exception
+    "TRY300", # Consider moving this statement to an `else` block
     "UP032", # Use f-string instead of `format` call
 ]
 

--- a/tests/__snapshots__/All_EndToEndTest.ambr
+++ b/tests/__snapshots__/All_EndToEndTest.ambr
@@ -1447,13 +1447,21 @@
           "ANN003", # Missing type annotation for `**kwargs`
           "BLE001", # Do not catch blind exception: `Exception`
           "COM812", # Trailing comma missing
+          "D105", # Missing docstring in magic method
+          "D107", # Missing docstring in `__init__` method
           "D202", # No blank lines allowed after function docstring
           "E501", # Line too long
+          "FIX002", # Line contains TODO, consider resolving the issue
           "I001", # Import block is un-sorted or un-formatted
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
+          "RSE102", # Unnecessary parentheses on raise exception
           "S101", # Use of assert detected
           "TC006", # Add quotes to type expression in `typing.cast()`
+          "TD002", # Missing author in TODO
+          "TD003", # Missing issue link for this TODO
+          "TRY002", # Create your own exception
+          "TRY300", # Consider moving this statement to an `else` block
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -2985,13 +2993,21 @@
           "ANN003", # Missing type annotation for `**kwargs`
           "BLE001", # Do not catch blind exception: `Exception`
           "COM812", # Trailing comma missing
+          "D105", # Missing docstring in magic method
+          "D107", # Missing docstring in `__init__` method
           "D202", # No blank lines allowed after function docstring
           "E501", # Line too long
+          "FIX002", # Line contains TODO, consider resolving the issue
           "I001", # Import block is un-sorted or un-formatted
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
+          "RSE102", # Unnecessary parentheses on raise exception
           "S101", # Use of assert detected
           "TC006", # Add quotes to type expression in `typing.cast()`
+          "TD002", # Missing author in TODO
+          "TD003", # Missing issue link for this TODO
+          "TRY002", # Create your own exception
+          "TRY300", # Consider moving this statement to an `else` block
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -4521,13 +4537,21 @@
           "ANN003", # Missing type annotation for `**kwargs`
           "BLE001", # Do not catch blind exception: `Exception`
           "COM812", # Trailing comma missing
+          "D105", # Missing docstring in magic method
+          "D107", # Missing docstring in `__init__` method
           "D202", # No blank lines allowed after function docstring
           "E501", # Line too long
+          "FIX002", # Line contains TODO, consider resolving the issue
           "I001", # Import block is un-sorted or un-formatted
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
+          "RSE102", # Unnecessary parentheses on raise exception
           "S101", # Use of assert detected
           "TC006", # Add quotes to type expression in `typing.cast()`
+          "TD002", # Missing author in TODO
+          "TD003", # Missing issue link for this TODO
+          "TRY002", # Create your own exception
+          "TRY300", # Consider moving this statement to an `else` block
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -6046,13 +6070,21 @@
           "ANN003", # Missing type annotation for `**kwargs`
           "BLE001", # Do not catch blind exception: `Exception`
           "COM812", # Trailing comma missing
+          "D105", # Missing docstring in magic method
+          "D107", # Missing docstring in `__init__` method
           "D202", # No blank lines allowed after function docstring
           "E501", # Line too long
+          "FIX002", # Line contains TODO, consider resolving the issue
           "I001", # Import block is un-sorted or un-formatted
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
+          "RSE102", # Unnecessary parentheses on raise exception
           "S101", # Use of assert detected
           "TC006", # Add quotes to type expression in `typing.cast()`
+          "TD002", # Missing author in TODO
+          "TD003", # Missing issue link for this TODO
+          "TRY002", # Create your own exception
+          "TRY300", # Consider moving this statement to an `else` block
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -7578,13 +7610,21 @@
           "ANN003", # Missing type annotation for `**kwargs`
           "BLE001", # Do not catch blind exception: `Exception`
           "COM812", # Trailing comma missing
+          "D105", # Missing docstring in magic method
+          "D107", # Missing docstring in `__init__` method
           "D202", # No blank lines allowed after function docstring
           "E501", # Line too long
+          "FIX002", # Line contains TODO, consider resolving the issue
           "I001", # Import block is un-sorted or un-formatted
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
+          "RSE102", # Unnecessary parentheses on raise exception
           "S101", # Use of assert detected
           "TC006", # Add quotes to type expression in `typing.cast()`
+          "TD002", # Missing author in TODO
+          "TD003", # Missing issue link for this TODO
+          "TRY002", # Create your own exception
+          "TRY300", # Consider moving this statement to an `else` block
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -9054,13 +9094,21 @@
           "ANN003", # Missing type annotation for `**kwargs`
           "BLE001", # Do not catch blind exception: `Exception`
           "COM812", # Trailing comma missing
+          "D105", # Missing docstring in magic method
+          "D107", # Missing docstring in `__init__` method
           "D202", # No blank lines allowed after function docstring
           "E501", # Line too long
+          "FIX002", # Line contains TODO, consider resolving the issue
           "I001", # Import block is un-sorted or un-formatted
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
+          "RSE102", # Unnecessary parentheses on raise exception
           "S101", # Use of assert detected
           "TC006", # Add quotes to type expression in `typing.cast()`
+          "TD002", # Missing author in TODO
+          "TD003", # Missing issue link for this TODO
+          "TRY002", # Create your own exception
+          "TRY300", # Consider moving this statement to an `else` block
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -10537,13 +10585,21 @@
           "ANN003", # Missing type annotation for `**kwargs`
           "BLE001", # Do not catch blind exception: `Exception`
           "COM812", # Trailing comma missing
+          "D105", # Missing docstring in magic method
+          "D107", # Missing docstring in `__init__` method
           "D202", # No blank lines allowed after function docstring
           "E501", # Line too long
+          "FIX002", # Line contains TODO, consider resolving the issue
           "I001", # Import block is un-sorted or un-formatted
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
+          "RSE102", # Unnecessary parentheses on raise exception
           "S101", # Use of assert detected
           "TC006", # Add quotes to type expression in `typing.cast()`
+          "TD002", # Missing author in TODO
+          "TD003", # Missing issue link for this TODO
+          "TRY002", # Create your own exception
+          "TRY300", # Consider moving this statement to an `else` block
           "UP032", # Use f-string instead of `format` call
       ]
       
@@ -12038,13 +12094,21 @@
           "ANN003", # Missing type annotation for `**kwargs`
           "BLE001", # Do not catch blind exception: `Exception`
           "COM812", # Trailing comma missing
+          "D105", # Missing docstring in magic method
+          "D107", # Missing docstring in `__init__` method
           "D202", # No blank lines allowed after function docstring
           "E501", # Line too long
+          "FIX002", # Line contains TODO, consider resolving the issue
           "I001", # Import block is un-sorted or un-formatted
           "N802", # Function name `xxx` should be lowercase
           "N999", # Invalid module name
+          "RSE102", # Unnecessary parentheses on raise exception
           "S101", # Use of assert detected
           "TC006", # Add quotes to type expression in `typing.cast()`
+          "TD002", # Missing author in TODO
+          "TD003", # Missing issue link for this TODO
+          "TRY002", # Create your own exception
+          "TRY300", # Consider moving this statement to an `else` block
           "UP032", # Use f-string instead of `format` call
       ]
       


### PR DESCRIPTION
## :pencil: Description
Disabled additional ruff warnings that were found to be spurious when running over multiple large code bases.

## :gear: Work Item
N/A

## :movie_camera: Demo
N/A