### PR TITLE
Changes based on external updates to `uv`

### DIFF
--- a/tests/__snapshots__/All_EndToEndTest.ambr
+++ b/tests/__snapshots__/All_EndToEndTest.ambr
@@ -1428,7 +1428,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.5,<0.9.0"]
+      requires = ["uv_build>=0.8.6,<0.9.0"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -2974,7 +2974,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.5,<0.9.0"]
+      requires = ["uv_build>=0.8.6,<0.9.0"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -4518,7 +4518,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.5,<0.9.0"]
+      requires = ["uv_build>=0.8.6,<0.9.0"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -6051,7 +6051,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.5,<0.9.0"]
+      requires = ["uv_build>=0.8.6,<0.9.0"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -7591,7 +7591,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.5,<0.9.0"]
+      requires = ["uv_build>=0.8.6,<0.9.0"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -9075,7 +9075,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.5,<0.9.0"]
+      requires = ["uv_build>=0.8.6,<0.9.0"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -10566,7 +10566,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.5,<0.9.0"]
+      requires = ["uv_build>=0.8.6,<0.9.0"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -12075,7 +12075,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.5,<0.9.0"]
+      requires = ["uv_build>=0.8.6,<0.9.0"]
       build-backend = "uv_build"
       
       [dependency-groups]


### PR DESCRIPTION
## :pencil: Description
`uv` changes rapidly, and the semantic version numbers associated with `uv_build` embedded in generated `pyproject.toml` files change frequently. The next time this happens, I will introduce a change that scrubs the version number before comparison.

## :gear: Work Item
N/A

## :movie_camera: Demo
N/A