### PR TITLE
Remove `uv_build` version info when comparing snapshots

### DIFF
--- a/tests/All_EndToEndTest.py
+++ b/tests/All_EndToEndTest.py
@@ -104,6 +104,17 @@ def test_All(configuration_info, copie, snapshot) -> None:
 
                 dependency_group_section["dev"] = sorted(versionless_dev_dependencies)
 
+                # build-system
+                build_system_section = cast(tomlkit.TOMLDocument, toml_content["build-system"])
+
+                requires = cast(list, build_system_section["requires"])
+
+                for require_index, require in enumerate(requires):
+                    if require.startswith("uv_build"):
+                        requires[require_index] = "<<uv_build>>"
+                        break
+
+                # Save the content
                 content = tomlkit.dumps(toml_content)
 
             results[(relative_path / filename).as_posix()] = content

--- a/tests/__snapshots__/All_EndToEndTest.ambr
+++ b/tests/__snapshots__/All_EndToEndTest.ambr
@@ -1428,7 +1428,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.6,<0.9.0"]
+      requires = ["<<uv_build>>"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -2974,7 +2974,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.6,<0.9.0"]
+      requires = ["<<uv_build>>"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -4518,7 +4518,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.6,<0.9.0"]
+      requires = ["<<uv_build>>"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -6051,7 +6051,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.6,<0.9.0"]
+      requires = ["<<uv_build>>"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -7591,7 +7591,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.6,<0.9.0"]
+      requires = ["<<uv_build>>"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -9075,7 +9075,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.6,<0.9.0"]
+      requires = ["<<uv_build>>"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -10566,7 +10566,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.6,<0.9.0"]
+      requires = ["<<uv_build>>"]
       build-backend = "uv_build"
       
       [dependency-groups]
@@ -12075,7 +12075,7 @@
       Repository = "https://github.com/<<github_username>>/<<github_repo_name>>"
       
       [build-system]
-      requires = ["uv_build>=0.8.6,<0.9.0"]
+      requires = ["<<uv_build>>"]
       build-backend = "uv_build"
       
       [dependency-groups]


### PR DESCRIPTION
## :pencil: Description
`uv_build` is frequently updated, which means that the `pyproject.toml` file generated by `uv init` is updated frequently as well. This change removes version information for `uv_build` from `pyproject.toml` for more stable comparisons.

## :gear: Work Item
N/A

## :movie_camera: Demo
N/A