### PR TITLE
PyPi Download link now uses strict python package name

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -167,4 +167,5 @@ _jinja_extensions:
   - extensions/context.py:ContextUpdater
   - extensions/slugify.py:SlugifyExtension
   - extensions/slugify.py:PythonPackageifyExtension
+  - extensions/slugify.py:PythonStrictPackageifyExtension
   - extensions/to_python_list.py:ToPythonListExtension

--- a/extensions/slugify.py
+++ b/extensions/slugify.py
@@ -58,3 +58,16 @@ class PythonPackageifyExtension(Extension):
         func = create_ify_func("_")
 
         environment.filters["pythonpackageify"] = lambda *args, **kwargs: func(*args, **kwargs).lower()
+
+
+class PythonStrictPackageifyExtension(Extension):
+    """Extension to convert a string to a strict python package name (all lowercase, underscores are converted to dashes)."""
+
+    def __init__(self, environment: Environment) -> None:  # noqa: D107
+        super().__init__(environment)
+
+        func = create_ify_func("_")
+
+        environment.filters["strictpythonpackageify"] = (
+            lambda *args, **kwargs: func(*args, **kwargs).lower().replace("_", "-")
+        )

--- a/template/__readme/__README.fragment.md
+++ b/template/__readme/__README.fragment.md
@@ -4,7 +4,7 @@
 **Package:**
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/{{ python_package_name }}?color=dark-green)](https://pypi.org/project/{{ python_package_name }}/)
 [![PyPI - Version](https://img.shields.io/pypi/v/{{ python_package_name }}?color=dark-green)](https://pypi.org/project/{{ python_package_name }}/)
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/{{ python_package_name }})](https://pypistats.org/packages/{{ python_package_name }})
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/{{ python_package_name }})](https://pypistats.org/packages/{{ python_package_name | strictpythonpackageify }})
 
 **Development:**
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)

--- a/tests/__snapshots__/All_EndToEndTest.ambr
+++ b/tests/__snapshots__/All_EndToEndTest.ambr
@@ -857,7 +857,7 @@
       **Package:**
       [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
       [![PyPI - Version](https://img.shields.io/pypi/v/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
-      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this_is_the_project_name)
+      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this-is-the-project-name)
       
       **Development:**
       [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
@@ -2440,7 +2440,7 @@
       **Package:**
       [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
       [![PyPI - Version](https://img.shields.io/pypi/v/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
-      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this_is_the_project_name)
+      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this-is-the-project-name)
       
       **Development:**
       [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
@@ -4021,7 +4021,7 @@
       **Package:**
       [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
       [![PyPI - Version](https://img.shields.io/pypi/v/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
-      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this_is_the_project_name)
+      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this-is-the-project-name)
       
       **Development:**
       [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
@@ -5591,7 +5591,7 @@
       **Package:**
       [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
       [![PyPI - Version](https://img.shields.io/pypi/v/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
-      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this_is_the_project_name)
+      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this-is-the-project-name)
       
       **Development:**
       [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
@@ -7168,7 +7168,7 @@
       **Package:**
       [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
       [![PyPI - Version](https://img.shields.io/pypi/v/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
-      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this_is_the_project_name)
+      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this-is-the-project-name)
       
       **Development:**
       [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
@@ -8744,7 +8744,7 @@
       **Package:**
       [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
       [![PyPI - Version](https://img.shields.io/pypi/v/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
-      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this_is_the_project_name)
+      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this-is-the-project-name)
       
       **Development:**
       [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
@@ -10264,7 +10264,7 @@
       **Package:**
       [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
       [![PyPI - Version](https://img.shields.io/pypi/v/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
-      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this_is_the_project_name)
+      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this-is-the-project-name)
       
       **Development:**
       [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
@@ -11769,7 +11769,7 @@
       **Package:**
       [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
       [![PyPI - Version](https://img.shields.io/pypi/v/this_is_the_project_name?color=dark-green)](https://pypi.org/project/this_is_the_project_name/)
-      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this_is_the_project_name)
+      [![PyPI - Downloads](https://img.shields.io/pypi/dm/this_is_the_project_name)](https://pypistats.org/packages/this-is-the-project-name)
       
       **Development:**
       [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)


### PR DESCRIPTION
## :pencil: Description
Before this change, the PyPi download link used the python package name which was broken when the name included uppercase characters or underscores. This change ensures that the link uses a package name where uppercase characters are converted to lowercase and underscore characters are converted to dashes.

## :gear: Work Item
https://github.com/gt-sse-center/copier-UvScaffolding/issues/35

## :movie_camera: Demo
N/A