### PR TITLE
Update repository URLs for gt-csse migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository is a [copier](https://copier.readthedocs.io/) template. However,
 | Description | Command Line |
 | --- | --- |
 | 1) Install uv (if it isn't already installed). | https://docs.astral.sh/uv/getting-started/installation/ |
-| 2) Clone this repository. | `git clone https://github.com/gt-sse-center/copier-UvScaffolding`
+| 2) Clone this repository. | `git clone https://github.com/gt-csse/copier-UvScaffolding`
 | 3) Initialize your local enlistment. | `uv sync` |
 
 ### Invoke `copier`

--- a/template/{{_copier_conf.answers_file}}
+++ b/template/{{_copier_conf.answers_file}}
@@ -1,9 +1,9 @@
 # Changes here will be overwritten by Copier; DO NOT MODIFY THIS FILE DIRECTLY!
 #
 # This file was generated using copier (https://copier.readthedocs.io/) with the
-# template copier-UvScaffolding (https://github.com/gt-sse-center/copier-UvScaffolding).
+# template copier-UvScaffolding (https://github.com/gt-csse/copier-UvScaffolding).
 # Additional information (including instructions on how to use this template with copier) is
-# available at https://github.com/gt-sse-center/copier-UvScaffolding.
+# available at https://github.com/gt-csse/copier-UvScaffolding.
 #
 
 {{ _copier_answers|to_nice_yaml -}}

--- a/tests/__snapshots__/All_EndToEndTest.ambr
+++ b/tests/__snapshots__/All_EndToEndTest.ambr
@@ -5,9 +5,9 @@
       # Changes here will be overwritten by Copier; DO NOT MODIFY THIS FILE DIRECTLY!
       #
       # This file was generated using copier (https://copier.readthedocs.io/) with the
-      # template copier-UvScaffolding (https://github.com/gt-sse-center/copier-UvScaffolding).
+      # template copier-UvScaffolding (https://github.com/gt-csse/copier-UvScaffolding).
       # Additional information (including instructions on how to use this template with copier) is
-      # available at https://github.com/gt-sse-center/copier-UvScaffolding.
+      # available at https://github.com/gt-csse/copier-UvScaffolding.
       #
       
       _commit: <<commit>>
@@ -1582,9 +1582,9 @@
       # Changes here will be overwritten by Copier; DO NOT MODIFY THIS FILE DIRECTLY!
       #
       # This file was generated using copier (https://copier.readthedocs.io/) with the
-      # template copier-UvScaffolding (https://github.com/gt-sse-center/copier-UvScaffolding).
+      # template copier-UvScaffolding (https://github.com/gt-csse/copier-UvScaffolding).
       # Additional information (including instructions on how to use this template with copier) is
-      # available at https://github.com/gt-sse-center/copier-UvScaffolding.
+      # available at https://github.com/gt-csse/copier-UvScaffolding.
       #
       
       _commit: <<commit>>
@@ -3173,9 +3173,9 @@
       # Changes here will be overwritten by Copier; DO NOT MODIFY THIS FILE DIRECTLY!
       #
       # This file was generated using copier (https://copier.readthedocs.io/) with the
-      # template copier-UvScaffolding (https://github.com/gt-sse-center/copier-UvScaffolding).
+      # template copier-UvScaffolding (https://github.com/gt-csse/copier-UvScaffolding).
       # Additional information (including instructions on how to use this template with copier) is
-      # available at https://github.com/gt-sse-center/copier-UvScaffolding.
+      # available at https://github.com/gt-csse/copier-UvScaffolding.
       #
       
       _commit: <<commit>>
@@ -4762,9 +4762,9 @@
       # Changes here will be overwritten by Copier; DO NOT MODIFY THIS FILE DIRECTLY!
       #
       # This file was generated using copier (https://copier.readthedocs.io/) with the
-      # template copier-UvScaffolding (https://github.com/gt-sse-center/copier-UvScaffolding).
+      # template copier-UvScaffolding (https://github.com/gt-csse/copier-UvScaffolding).
       # Additional information (including instructions on how to use this template with copier) is
-      # available at https://github.com/gt-sse-center/copier-UvScaffolding.
+      # available at https://github.com/gt-csse/copier-UvScaffolding.
       #
       
       _commit: <<commit>>
@@ -6340,9 +6340,9 @@
       # Changes here will be overwritten by Copier; DO NOT MODIFY THIS FILE DIRECTLY!
       #
       # This file was generated using copier (https://copier.readthedocs.io/) with the
-      # template copier-UvScaffolding (https://github.com/gt-sse-center/copier-UvScaffolding).
+      # template copier-UvScaffolding (https://github.com/gt-csse/copier-UvScaffolding).
       # Additional information (including instructions on how to use this template with copier) is
-      # available at https://github.com/gt-sse-center/copier-UvScaffolding.
+      # available at https://github.com/gt-csse/copier-UvScaffolding.
       #
       
       _commit: <<commit>>
@@ -7925,9 +7925,9 @@
       # Changes here will be overwritten by Copier; DO NOT MODIFY THIS FILE DIRECTLY!
       #
       # This file was generated using copier (https://copier.readthedocs.io/) with the
-      # template copier-UvScaffolding (https://github.com/gt-sse-center/copier-UvScaffolding).
+      # template copier-UvScaffolding (https://github.com/gt-csse/copier-UvScaffolding).
       # Additional information (including instructions on how to use this template with copier) is
-      # available at https://github.com/gt-sse-center/copier-UvScaffolding.
+      # available at https://github.com/gt-csse/copier-UvScaffolding.
       #
       
       _commit: <<commit>>
@@ -9453,9 +9453,9 @@
       # Changes here will be overwritten by Copier; DO NOT MODIFY THIS FILE DIRECTLY!
       #
       # This file was generated using copier (https://copier.readthedocs.io/) with the
-      # template copier-UvScaffolding (https://github.com/gt-sse-center/copier-UvScaffolding).
+      # template copier-UvScaffolding (https://github.com/gt-csse/copier-UvScaffolding).
       # Additional information (including instructions on how to use this template with copier) is
-      # available at https://github.com/gt-sse-center/copier-UvScaffolding.
+      # available at https://github.com/gt-csse/copier-UvScaffolding.
       #
       
       _commit: <<commit>>
@@ -10989,9 +10989,9 @@
       # Changes here will be overwritten by Copier; DO NOT MODIFY THIS FILE DIRECTLY!
       #
       # This file was generated using copier (https://copier.readthedocs.io/) with the
-      # template copier-UvScaffolding (https://github.com/gt-sse-center/copier-UvScaffolding).
+      # template copier-UvScaffolding (https://github.com/gt-csse/copier-UvScaffolding).
       # Additional information (including instructions on how to use this template with copier) is
-      # available at https://github.com/gt-sse-center/copier-UvScaffolding.
+      # available at https://github.com/gt-csse/copier-UvScaffolding.
       #
       
       _commit: <<commit>>
@@ -12543,9 +12543,9 @@
       # Changes here will be overwritten by Copier; DO NOT MODIFY THIS FILE DIRECTLY!
       #
       # This file was generated using copier (https://copier.readthedocs.io/) with the
-      # template copier-UvScaffolding (https://github.com/gt-sse-center/copier-UvScaffolding).
+      # template copier-UvScaffolding (https://github.com/gt-csse/copier-UvScaffolding).
       # Additional information (including instructions on how to use this template with copier) is
-      # available at https://github.com/gt-sse-center/copier-UvScaffolding.
+      # available at https://github.com/gt-csse/copier-UvScaffolding.
       #
       
       _commit: <<commit>>


### PR DESCRIPTION
## :pencil: Description

- Update the README clone command to point at `gt-csse/copier-UvScaffolding`
- Update generated Copier answer-file comments to reference the new GitHub organization
- Refresh snapshot output for the generated answer-file text