### PR TITLE
Fixed shell exec commands to use list vs str pattern

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,4 +1,5 @@
 # noqa: D100
+import shlex
 import subprocess
 import sys
 import textwrap
@@ -117,7 +118,7 @@ def Update(
 # ----------------------------------------------------------------------
 def _CheckUvVersion() -> bool:
     result = subprocess.run(
-        "uv self update --dry-run",  # noqa: S607
+        ["uv", "self", "update", "--dry-run"],
         capture_output=True,
         check=False,
         text=True,
@@ -155,9 +156,8 @@ def _Execute(
 
         try:
             subprocess.run(  # noqa: S603
-                command_line,
+                shlex.split(command_line),
                 stderr=subprocess.STDOUT,
-                stdin=subprocess.PIPE,
                 stdout=sys.stdout,
                 check=True,
             )

--- a/run.py
+++ b/run.py
@@ -118,7 +118,7 @@ def Update(
 # ----------------------------------------------------------------------
 def _CheckUvVersion() -> bool:
     result = subprocess.run(
-        ["uv", "self", "update", "--dry-run"],
+        ["uv", "self", "update", "--dry-run"],  # noqa: S607
         capture_output=True,
         check=False,
         text=True,


### PR DESCRIPTION
## :pencil: Description
Shell executions were failing on macOS/bash due to an entire command string being passed vs a list of command line arguments, which is the preferred method for invoking shell commands.

Error:
```bash
$ uv run run.py Copy ../text-repo
Traceback (most recent call last):
  File "/Users/rbates8/src/copier-UvScaffolding/run.py", line 174, in <module>
    app()  # pragma: no cover
    ~~~^^
  File "/Users/rbates8/src/copier-UvScaffolding/.venv/lib/python3.14/site-packages/typer/main.py", line 1152, in __call__
    raise e
  File "/Users/rbates8/src/copier-UvScaffolding/.venv/lib/python3.14/site-packages/typer/main.py", line 1135, in __call__
    return get_command(self)(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/rbates8/src/copier-UvScaffolding/.venv/lib/python3.14/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/rbates8/src/copier-UvScaffolding/.venv/lib/python3.14/site-packages/typer/core.py", line 795, in main
    return _main(
        self,
    ...<6 lines>...
        **extra,
    )
  File "/Users/rbates8/src/copier-UvScaffolding/.venv/lib/python3.14/site-packages/typer/core.py", line 188, in _main
    rv = self.invoke(ctx)
  File "/Users/rbates8/src/copier-UvScaffolding/.venv/lib/python3.14/site-packages/click/core.py", line 1873, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/rbates8/src/copier-UvScaffolding/.venv/lib/python3.14/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rbates8/src/copier-UvScaffolding/.venv/lib/python3.14/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "/Users/rbates8/src/copier-UvScaffolding/.venv/lib/python3.14/site-packages/typer/main.py", line 1514, in wrapper
    return callback(**use_params)
  File "/Users/rbates8/src/copier-UvScaffolding/run.py", line 52, in Copy
    _Execute(
    ~~~~~~~~^
        f"""uv run copier copy "{Path(__file__).parent}" "{output_directory}" --trust {" ".join('"{}"'.format(arg) for arg in additional_args)}""",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        skip_uv_version_check=skip_uv_version_check,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ),
    ^
  File "/Users/rbates8/src/copier-UvScaffolding/run.py", line 153, in _Execute
    if skip_uv_version_check or _CheckUvVersion():
                                ~~~~~~~~~~~~~~~^^
  File "/Users/rbates8/src/copier-UvScaffolding/run.py", line 119, in _CheckUvVersion
    result = subprocess.run(
        "uv self update --dry-run",  # noqa: S607
    ...<2 lines>...
        text=True,
    )
  File "/Users/rbates8/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/subprocess.py", line 554, in run
    with Popen(*popenargs, **kwargs) as process:
         ~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rbates8/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/subprocess.py", line 1038, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                        pass_fds, cwd, env,
                        ^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
                        gid, gids, uid, umask,
                        ^^^^^^^^^^^^^^^^^^^^^^
                        start_new_session, process_group)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rbates8/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/subprocess.py", line 1989, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'uv self update --dry-run'
```

## :gear: Work Item
n/a

## :movie_camera: Demo
Application executes as expected with this PR under macOS+bash, and should generalize better for other shells as well.