### PR TITLE
#67: Added pytest conf to properly set UV python versions so they align b/t gen and assert

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+from plumbum import local
+
+
+def pytest_configure(config):
+    # Pin uv's Python to the test runner's Python so subprocess `uv init`
+    # calls in the template-render path produce a `.python-version` that
+    # matches `sys.version_info` (what All_EndToEndTest.py:69 asserts).
+    # CI does this implicitly via `astral-sh/setup-uv`; setdefault preserves
+    # an explicit override (e.g. `UV_PYTHON=3.11 uv run pytest`).
+    #
+    # We also have to update `plumbum.local.env`: copier executes `_tasks`
+    # via `subprocess.run(..., env=local.env)`, and plumbum's LocalEnv
+    # snapshots `os.environ` at instantiation (which happens when pytest-copie
+    # imports plumbum, before this hook runs). Updating only `os.environ`
+    # would leave the snapshot stale and the variable wouldn't reach the
+    # `uv init` subprocess.
+    uv_python = os.environ.setdefault(
+        "UV_PYTHON",
+        ".".join(str(i) for i in sys.version_info[:2]),
+    )
+    local.env["UV_PYTHON"] = uv_python


### PR DESCRIPTION
## :pencil: Description
Added `tests/conftest.py` with a new pytest config callback to properly align the uv python version used to generate the template with the one used to execute the tests so Python version checks of generated code don't fail on a local dev env.

## :gear: Work Item
Closes #67 

## :movie_camera: Demo
n/a
