### PR TITLE
#65: Added explicit upper version on typer in template pending upstream fix

### DIFF
--- a/template/__tools/UvInit.py
+++ b/template/__tools/UvInit.py
@@ -1,5 +1,4 @@
 # noqa: D100
-import shlex
 import sys
 import textwrap
 
@@ -74,7 +73,7 @@ def _RunUvInit(indented_stream: StreamDecorator) -> bool:
             dev_dependencies.append("ty")
 {% endif %}
 
-            command_line = f"uv add {' '.join(shlex.quote(d) for d in dev_dependencies)} --dev"
+            command_line = "uv add {} --dev".format(" ".join(f'"{d}"' for d in dev_dependencies))
 
             dm.WriteVerbose(f"Command line: {command_line}\n\n")
 

--- a/template/__tools/UvInit.py
+++ b/template/__tools/UvInit.py
@@ -1,4 +1,5 @@
 # noqa: D100
+import shlex
 import sys
 import textwrap
 
@@ -62,6 +63,7 @@ def _RunUvInit(indented_stream: StreamDecorator) -> bool:
                 "pytest",
                 "pytest-cov",
                 "ruff",
+                "typer<0.26",
             ]
 
 {% if sign_artifacts_question %}
@@ -72,7 +74,7 @@ def _RunUvInit(indented_stream: StreamDecorator) -> bool:
             dev_dependencies.append("ty")
 {% endif %}
 
-            command_line = f"uv add {' '.join(dev_dependencies)} --dev"
+            command_line = f"uv add {' '.join(shlex.quote(d) for d in dev_dependencies)} --dev"
 
             dm.WriteVerbose(f"Command line: {command_line}\n\n")
 

--- a/tests/__snapshots__/All_EndToEndTest.ambr
+++ b/tests/__snapshots__/All_EndToEndTest.ambr
@@ -1473,7 +1473,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -3064,7 +3064,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -4653,7 +4653,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -6231,7 +6231,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -7816,7 +7816,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -9344,7 +9344,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -10880,7 +10880,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "pytest", "pytest-cov", "ruff"]
+      dev = ["autogitsemver", "pre-commit", "pytest", "pytest-cov", "ruff", "typer<0.26"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -12434,7 +12434,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -14028,7 +14028,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "ty"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "ty", "typer<0.26"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"

--- a/tests/__snapshots__/All_EndToEndTest.ambr
+++ b/tests/__snapshots__/All_EndToEndTest.ambr
@@ -1473,7 +1473,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -3064,7 +3064,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -4653,7 +4653,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -6231,7 +6231,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -7816,7 +7816,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -9344,7 +9344,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -10880,7 +10880,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "pytest", "pytest-cov", "ruff", "typer<0.26"]
+      dev = ["autogitsemver", "pre-commit", "pytest", "pytest-cov", "ruff", "typer"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -12434,7 +12434,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer<0.26"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "typer"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"
@@ -14028,7 +14028,7 @@
       build-backend = "uv_build"
       
       [dependency-groups]
-      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "ty", "typer<0.26"]
+      dev = ["autogitsemver", "pre-commit", "py-minisign", "pytest", "pytest-cov", "ruff", "ty", "typer"]
       
       [tool.pytest.ini_options]
       addopts = "--verbose -vv --capture=no --cov=this_is_the_project_name --cov-report html --cov-report term --cov-report xml:coverage.xml --cov-fail-under=95.0"


### PR DESCRIPTION
## :pencil: Description
Added explicit `typer` upper version in template's `pyproject.toml` file to prevent build failures due to a transitive dependency on the `click` package that was removed in `typer>=26`

## :gear: Work Item
Closes #65 

## :movie_camera: Demo
Correctly running CICD action output:

```bash
$ uv run python -m AutoGitSemVer.scripts.UpdatePythonVersion ./pyproject.toml ./src --verbose
Loading AutoGitSemVer configuration...DONE! (0, 0:00:00.001009, configuration info found at '/private/tmp/scratch-project/src/AutoGitSemVer.yaml')
Enumerating changes...
  VERBOSE: Processing '130d3707a719e093576959908dff0bc702a75837' (2026-05-29 13:37:26-04:00)...DONE! (0, 0:00:00.000037, 0.0.1)
DONE! (0, 0:00:00.056398, 1 change processed, 1 change applied [100.00%])
Calculating semantic version...
  0.1.0
DONE! (0, 0:00:00.017141)

Updating '/private/tmp/scratch-project/pyproject.toml'...DONE! (0, 0:00:00.000551)

Results: DONE! (0, 0:00:00.076012)
```
