### PR TITLE
Refined instructions associated with `uv sync`

### DIFF
--- a/template/__post_generation_instructions/__postprocess.py
+++ b/template/__post_generation_instructions/__postprocess.py
@@ -17,7 +17,7 @@ def Execute():
     _CreateGitHubSettings(instructions)
     _CreateTemporaryPyPiToken(instructions)
     _CreateMinisignSecret(instructions)
-    _CreateUvInstructions(instructions)
+    _CreateInitializeInstructions(instructions)
     _CreatePreCommitInstructions(instructions)
     _CreateCommitInstructions(instructions)
 
@@ -245,12 +245,10 @@ def _CreateMinisignSecret(instructions: dict[str, str]) -> None:
 
 
 # ----------------------------------------------------------------------
-def _CreateUvInstructions(instructions: dict[str, str]) -> None:
-    instructions["Install uv locally"] = textwrap.dedent(
+def _CreateInitializeInstructions(instructions: dict[str, str]) -> None:
+    instructions["Initialize dependencies"] = textwrap.dedent(
         """\
-        <p>In this step, we will install <a href="https://docs.astral.sh/uv" target="_blank">uv</a> for local development (if necessary) and initialize its dependencies.</p>
-
-        <p>To install <code>uv</code> locally, follow the instructions at <a href="https://docs.astral.sh/uv/#installation" target="_blank">https://docs.astral.sh/uv/#installation</a>.</p>
+        <p>In this step, we will initialize local python dependencies using <a href="https://docs.astral.sh/uv" target="_blank">uv</a>.</p>
 
         <p>To initialize this repository's dependencies, open a terminal window, navigate to your repository, and run the following command:</p>
 

--- a/tests/__snapshots__/All_EndToEndTest.ambr
+++ b/tests/__snapshots__/All_EndToEndTest.ambr
@@ -1243,13 +1243,11 @@
       
       <details>
         <summary>
-          <span role="term"><input type="checkbox" id="install-uv-locally">10) Install uv locally</span>
+          <span role="term"><input type="checkbox" id="initialize-dependencies">10) Initialize dependencies</span>
         </summary>
       </details>
       <div role="definition" class="details-content">
-        <p>In this step, we will install <a href="https://docs.astral.sh/uv" target="_blank">uv</a> for local development (if necessary) and initialize its dependencies.</p>
-      
-      <p>To install <code>uv</code> locally, follow the instructions at <a href="https://docs.astral.sh/uv/#installation" target="_blank">https://docs.astral.sh/uv/#installation</a>.</p>
+        <p>In this step, we will initialize local python dependencies using <a href="https://docs.astral.sh/uv" target="_blank">uv</a>.</p>
       
       <p>To initialize this repository's dependencies, open a terminal window, navigate to your repository, and run the following command:</p>
       
@@ -2833,13 +2831,11 @@
       
       <details>
         <summary>
-          <span role="term"><input type="checkbox" id="install-uv-locally">10) Install uv locally</span>
+          <span role="term"><input type="checkbox" id="initialize-dependencies">10) Initialize dependencies</span>
         </summary>
       </details>
       <div role="definition" class="details-content">
-        <p>In this step, we will install <a href="https://docs.astral.sh/uv" target="_blank">uv</a> for local development (if necessary) and initialize its dependencies.</p>
-      
-      <p>To install <code>uv</code> locally, follow the instructions at <a href="https://docs.astral.sh/uv/#installation" target="_blank">https://docs.astral.sh/uv/#installation</a>.</p>
+        <p>In this step, we will initialize local python dependencies using <a href="https://docs.astral.sh/uv" target="_blank">uv</a>.</p>
       
       <p>To initialize this repository's dependencies, open a terminal window, navigate to your repository, and run the following command:</p>
       
@@ -4421,13 +4417,11 @@
       
       <details>
         <summary>
-          <span role="term"><input type="checkbox" id="install-uv-locally">10) Install uv locally</span>
+          <span role="term"><input type="checkbox" id="initialize-dependencies">10) Initialize dependencies</span>
         </summary>
       </details>
       <div role="definition" class="details-content">
-        <p>In this step, we will install <a href="https://docs.astral.sh/uv" target="_blank">uv</a> for local development (if necessary) and initialize its dependencies.</p>
-      
-      <p>To install <code>uv</code> locally, follow the instructions at <a href="https://docs.astral.sh/uv/#installation" target="_blank">https://docs.astral.sh/uv/#installation</a>.</p>
+        <p>In this step, we will initialize local python dependencies using <a href="https://docs.astral.sh/uv" target="_blank">uv</a>.</p>
       
       <p>To initialize this repository's dependencies, open a terminal window, navigate to your repository, and run the following command:</p>
       
@@ -5998,13 +5992,11 @@
       
       <details>
         <summary>
-          <span role="term"><input type="checkbox" id="install-uv-locally">10) Install uv locally</span>
+          <span role="term"><input type="checkbox" id="initialize-dependencies">10) Initialize dependencies</span>
         </summary>
       </details>
       <div role="definition" class="details-content">
-        <p>In this step, we will install <a href="https://docs.astral.sh/uv" target="_blank">uv</a> for local development (if necessary) and initialize its dependencies.</p>
-      
-      <p>To install <code>uv</code> locally, follow the instructions at <a href="https://docs.astral.sh/uv/#installation" target="_blank">https://docs.astral.sh/uv/#installation</a>.</p>
+        <p>In this step, we will initialize local python dependencies using <a href="https://docs.astral.sh/uv" target="_blank">uv</a>.</p>
       
       <p>To initialize this repository's dependencies, open a terminal window, navigate to your repository, and run the following command:</p>
       
@@ -7582,13 +7574,11 @@
       
       <details>
         <summary>
-          <span role="term"><input type="checkbox" id="install-uv-locally">10) Install uv locally</span>
+          <span role="term"><input type="checkbox" id="initialize-dependencies">10) Initialize dependencies</span>
         </summary>
       </details>
       <div role="definition" class="details-content">
-        <p>In this step, we will install <a href="https://docs.astral.sh/uv" target="_blank">uv</a> for local development (if necessary) and initialize its dependencies.</p>
-      
-      <p>To install <code>uv</code> locally, follow the instructions at <a href="https://docs.astral.sh/uv/#installation" target="_blank">https://docs.astral.sh/uv/#installation</a>.</p>
+        <p>In this step, we will initialize local python dependencies using <a href="https://docs.astral.sh/uv" target="_blank">uv</a>.</p>
       
       <p>To initialize this repository's dependencies, open a terminal window, navigate to your repository, and run the following command:</p>
       
@@ -9109,13 +9099,11 @@
       
       <details>
         <summary>
-          <span role="term"><input type="checkbox" id="install-uv-locally">8) Install uv locally</span>
+          <span role="term"><input type="checkbox" id="initialize-dependencies">8) Initialize dependencies</span>
         </summary>
       </details>
       <div role="definition" class="details-content">
-        <p>In this step, we will install <a href="https://docs.astral.sh/uv" target="_blank">uv</a> for local development (if necessary) and initialize its dependencies.</p>
-      
-      <p>To install <code>uv</code> locally, follow the instructions at <a href="https://docs.astral.sh/uv/#installation" target="_blank">https://docs.astral.sh/uv/#installation</a>.</p>
+        <p>In this step, we will initialize local python dependencies using <a href="https://docs.astral.sh/uv" target="_blank">uv</a>.</p>
       
       <p>To initialize this repository's dependencies, open a terminal window, navigate to your repository, and run the following command:</p>
       
@@ -10644,13 +10632,11 @@
       
       <details>
         <summary>
-          <span role="term"><input type="checkbox" id="install-uv-locally">8) Install uv locally</span>
+          <span role="term"><input type="checkbox" id="initialize-dependencies">8) Initialize dependencies</span>
         </summary>
       </details>
       <div role="definition" class="details-content">
-        <p>In this step, we will install <a href="https://docs.astral.sh/uv" target="_blank">uv</a> for local development (if necessary) and initialize its dependencies.</p>
-      
-      <p>To install <code>uv</code> locally, follow the instructions at <a href="https://docs.astral.sh/uv/#installation" target="_blank">https://docs.astral.sh/uv/#installation</a>.</p>
+        <p>In this step, we will initialize local python dependencies using <a href="https://docs.astral.sh/uv" target="_blank">uv</a>.</p>
       
       <p>To initialize this repository's dependencies, open a terminal window, navigate to your repository, and run the following command:</p>
       
@@ -12200,13 +12186,11 @@
       
       <details>
         <summary>
-          <span role="term"><input type="checkbox" id="install-uv-locally">10) Install uv locally</span>
+          <span role="term"><input type="checkbox" id="initialize-dependencies">10) Initialize dependencies</span>
         </summary>
       </details>
       <div role="definition" class="details-content">
-        <p>In this step, we will install <a href="https://docs.astral.sh/uv" target="_blank">uv</a> for local development (if necessary) and initialize its dependencies.</p>
-      
-      <p>To install <code>uv</code> locally, follow the instructions at <a href="https://docs.astral.sh/uv/#installation" target="_blank">https://docs.astral.sh/uv/#installation</a>.</p>
+        <p>In this step, we will initialize local python dependencies using <a href="https://docs.astral.sh/uv" target="_blank">uv</a>.</p>
       
       <p>To initialize this repository's dependencies, open a terminal window, navigate to your repository, and run the following command:</p>
       
@@ -13790,13 +13774,11 @@
       
       <details>
         <summary>
-          <span role="term"><input type="checkbox" id="install-uv-locally">10) Install uv locally</span>
+          <span role="term"><input type="checkbox" id="initialize-dependencies">10) Initialize dependencies</span>
         </summary>
       </details>
       <div role="definition" class="details-content">
-        <p>In this step, we will install <a href="https://docs.astral.sh/uv" target="_blank">uv</a> for local development (if necessary) and initialize its dependencies.</p>
-      
-      <p>To install <code>uv</code> locally, follow the instructions at <a href="https://docs.astral.sh/uv/#installation" target="_blank">https://docs.astral.sh/uv/#installation</a>.</p>
+        <p>In this step, we will initialize local python dependencies using <a href="https://docs.astral.sh/uv" target="_blank">uv</a>.</p>
       
       <p>To initialize this repository's dependencies, open a terminal window, navigate to your repository, and run the following command:</p>
       


### PR DESCRIPTION
## :pencil: Description
Refined instructions associated with `uv sync`.

Previously, we included instructions to install uv. However, uv will have already been invoked earlier in the generation process.

## :gear: Work Item
#79 

## :movie_camera: Demo
N/A